### PR TITLE
Extend codegen

### DIFF
--- a/hack/gen-features/main.go
+++ b/hack/gen-features/main.go
@@ -12,10 +12,9 @@ import (
 )
 
 const (
-	fileTemplate = `package licenseapi
-// This code was generated. Change features.yaml to add, remove, or edit features.
+	featuresFileTemplate = `package licenseapi
 
-//go:generate go run ../../hack/gen-features/main.go
+// This code was generated. Change features.yaml to add, remove, or edit features.
 
 // Features
 const (
@@ -25,6 +24,40 @@ const (
 func GetFeatures() []FeatureName {
 	return []FeatureName{
 %s
+	}
+}
+`
+	defaultLicenseFileTemplate = `package licenseapi
+
+// This code was generated. Change features.yaml to add, remove, or edit features.
+
+import (
+	"cmp"
+	"slices"
+)
+
+func New() *License {
+	limits := make([]*Limit, 0, len(Limits))
+	for _, limit := range Limits {
+		limits = append(limits, limit)
+	}
+	slices.SortFunc(limits, func(a, b *Limit) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	// Sorting features by module is not requires here. However, to maintain backwards compatibility, the structure of
+	// features being contained within a module is still necessary. Therefore, all features are now returned in one module.
+	return &License{
+		Modules: []*Module{
+			{
+				DisplayName: "All Features",
+				Name:        string(VirtualClusterModule),
+				Limits:      limits,
+				Features: []*Feature{
+%s
+				},
+			},
+		},
 	}
 }
 `
@@ -63,10 +96,7 @@ func main() {
 		panic(err)
 	}
 
-	features := struct {
-		Features []licenseapi.Feature `json:"features"`
-	}{}
-	err = yaml.Unmarshal(bytes, &features)
+	features, err := featuresUnmarshal(bytes)
 	if err != nil {
 		panic(err)
 	}
@@ -76,13 +106,23 @@ func main() {
 		panic(err)
 	}
 
-	_, err = f.WriteString(fmt.Sprintf(fileTemplate, generateFeatureConstantsBody(features.Features), generateFeatureSliceBody(features.Features)))
+	_, err = f.WriteString(fmt.Sprintf(featuresFileTemplate, generateFeatureConstantsBody(features), generateFeatureSliceBody(features)))
+	if err != nil {
+		panic(err)
+	}
+
+	f, err = os.Create("../../pkg/licenseapi/license_new.go")
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = f.WriteString(fmt.Sprintf(defaultLicenseFileTemplate, generatedDefaultLicenseBody(features)))
 	if err != nil {
 		panic(err)
 	}
 }
 
-func generateFeatureConstantsBody(features []licenseapi.Feature) string {
+func generateFeatureConstantsBody(features []*licenseapi.Feature) string {
 	featureConstants := ""
 	for _, feature := range features {
 		featureConstants += fmt.Sprintf(`	%s FeatureName = "%s" // %s
@@ -92,7 +132,7 @@ func generateFeatureConstantsBody(features []licenseapi.Feature) string {
 	return strings.TrimSuffix(featureConstants, "\n")
 }
 
-func generateFeatureSliceBody(features []licenseapi.Feature) string {
+func generateFeatureSliceBody(features []*licenseapi.Feature) string {
 	featuresList := ""
 	for _, feature := range features {
 		featuresList += fmt.Sprintf(`		%s,
@@ -119,8 +159,31 @@ func replaceAliasWithFull(feature string) string {
 	return feature
 }
 
+func generatedDefaultLicenseBody(features []*licenseapi.Feature) string {
+	moduleFeatures := ""
+	for _, feature := range features {
+		moduleFeatures += fmt.Sprintf(`					{
+						DisplayName: "%s",
+						Name:        "%s",
+					},
+`, feature.DisplayName, feature.Name)
+	}
+	return strings.TrimSuffix(moduleFeatures, "\n")
+}
+
 func hyphenatedToCamelCase(name string) string {
 	return reg.ReplaceAllStringFunc(name, func(s string) string {
 		return strings.ToUpper(string(strings.TrimPrefix(s, "-")[0])) + strings.TrimPrefix(s, "-")[1:]
 	})
+}
+
+func featuresUnmarshal(body []byte) ([]*licenseapi.Feature, error) {
+	features := struct {
+		Features []*licenseapi.Feature `json:"features"`
+	}{}
+	err := yaml.Unmarshal(body, &features)
+	if err != nil {
+		return nil, err
+	}
+	return features.Features, nil
 }

--- a/pkg/licenseapi/features.go
+++ b/pkg/licenseapi/features.go
@@ -1,7 +1,6 @@
 package licenseapi
-// This code was generated. Change features.yaml to add, remove, or edit features.
 
-//go:generate go run ../../hack/gen-features/main.go
+// This code was generated. Change features.yaml to add, remove, or edit features.
 
 // Features
 const (

--- a/pkg/licenseapi/generate.go
+++ b/pkg/licenseapi/generate.go
@@ -1,0 +1,3 @@
+package licenseapi
+
+//go:generate go run ../../hack/gen-features/main.go

--- a/pkg/licenseapi/license_limit.go
+++ b/pkg/licenseapi/license_limit.go
@@ -1,5 +1,28 @@
 package licenseapi
 
+var Limits = map[ResourceName]*Limit{
+	ConnectedClusterLimit: {
+		DisplayName: "Connected Clusters",
+		Name:        string(ConnectedClusterLimit),
+	},
+	VirtualClusterInstanceLimit: {
+		DisplayName: "Virtual Clusters",
+		Name:        string(VirtualClusterInstanceLimit),
+	},
+	DevPodWorkspaceInstanceLimit: {
+		DisplayName: "Dev Environments",
+		Name:        string(DevPodWorkspaceInstanceLimit),
+	},
+	UserLimit: {
+		DisplayName: "Users",
+		Name:        string(UserLimit),
+	},
+	InstanceLimit: {
+		DisplayName: "Instances",
+		Name:        string(InstanceLimit),
+	},
+}
+
 // Limit defines a limit set in the license
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=true

--- a/pkg/licenseapi/license_new.go
+++ b/pkg/licenseapi/license_new.go
@@ -1,11 +1,23 @@
 package licenseapi
 
+// This code was generated. Change features.yaml to add, remove, or edit features.
+
+import (
+	"cmp"
+	"slices"
+)
+
 func New() *License {
 	limits := make([]*Limit, 0, len(Limits))
 	for _, limit := range Limits {
 		limits = append(limits, limit)
 	}
+	slices.SortFunc(limits, func(a, b *Limit) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
+	// Sorting features by module is not requires here. However, to maintain backwards compatibility, the structure of
+	// features being contained within a module is still necessary. Therefore, all features are now returned in one module.
 	return &License{
 		Modules: []*Module{
 			{
@@ -15,184 +27,175 @@ func New() *License {
 				Features: []*Feature{
 					{
 						DisplayName: "Virtual Cluster Management",
-						Name:        string(VirtualCluster),
+						Name:        "vclusters",
 					},
 					{
 						DisplayName: "Sleep Mode for Virtual Clusters",
-						Name:        string(VirtualClusterSleepMode),
+						Name:        "vcluster-sleep-mode",
 					},
 					{
 						DisplayName: "Central HostPath Mapper",
-						Name:        string(VirtualClusterHostPathMapper),
+						Name:        "vcluster-host-path-mapper",
 					},
 					{
 						DisplayName: "Enterprise Plugins",
-						Name:        string(VirtualClusterEnterprisePlugins),
+						Name:        "vcluster-enterprise-plugins",
 					},
 					{
 						DisplayName: "Security-Hardened vCluster Image",
-						Name:        string(VirtualClusterProDistroImage),
+						Name:        "vcp-distro-image",
 					},
 					{
 						DisplayName: "Built-In CoreDNS",
-						Name:        string(VirtualClusterProDistroBuiltInCoreDNS),
+						Name:        "vcp-distro-built-in-coredns",
 					},
 					{
 						DisplayName: "Virtual Admission Control",
-						Name:        string(VirtualClusterProDistroAdmissionControl),
-						Status:      string(FeatureStatusHidden),
+						Name:        "vcp-distro-admission-control",
 					},
 					{
 						DisplayName: "Sync Patches",
-						Name:        string(VirtualClusterProDistroSyncPatches),
+						Name:        "vcp-distro-sync-patches",
 					},
 					{
 						DisplayName: "Embedded etcd",
-						Name:        string(VirtualClusterProDistroEmbeddedEtcd),
+						Name:        "vcp-distro-embedded-etcd",
 					},
 					{
 						DisplayName: "Isolated Control Plane",
-						Name:        string(VirtualClusterProDistroIsolatedControlPlane),
+						Name:        "vcp-distro-isolated-cp",
 					},
 					{
 						DisplayName: "Centralized Admission Control",
-						Name:        string(VirtualClusterProDistroCentralizedAdmissionControl),
+						Name:        "vcp-distro-centralized-admission-control",
 					},
 					{
 						DisplayName: "Generic Sync",
-						Name:        string(VirtualClusterProDistroGenericSync),
+						Name:        "vcp-distro-generic-sync",
 					},
 					{
 						DisplayName: "Translate Patches",
-						Name:        string(VirtualClusterProDistroTranslatePatches),
+						Name:        "vcp-distro-translate-patches",
 					},
 					{
 						DisplayName: "KubeVirt Integration",
-						Name:        string(VirtualClusterProDistroIntegrationsKubeVirt),
+						Name:        "vcp-distro-integrations-kube-virt",
 					},
 					{
 						DisplayName: "External Secrets Integration",
-						Name:        string(VirtualClusterProDistroIntegrationsExternalSecrets),
+						Name:        "vcp-distro-integrations-external-secrets",
 					},
 					{
 						DisplayName: "Cert Manager Integration",
-						Name:        string(VirtualClusterProDistroIntegrationsCertManager),
+						Name:        "vcp-distro-integrations-cert-manager",
 					},
 					{
 						DisplayName: "FIPS",
-						Name:        string(VirtualClusterProDistroFips),
+						Name:        "vcp-distro-fips",
 					},
 					{
 						DisplayName: "External Database",
-						Name:        string(VirtualClusterProDistroExternalDatabase),
+						Name:        "vcp-distro-external-database",
 					},
 					{
 						DisplayName: "Database Connector",
-						Name:        string(ConnectorExternalDatabase),
+						Name:        "connector-external-database",
 					},
 					{
 						DisplayName: "SleepMode",
-						Name:        string(VirtualClusterProDistroSleepMode),
+						Name:        "vcp-distro-sleep-mode",
 					},
 					{
 						DisplayName: "Dev Environment Management",
-						Name:        string(Devpod),
+						Name:        "devpod",
 					},
 					{
 						DisplayName: "Namespace Management",
-						Name:        string(Namespaces),
+						Name:        "namespaces",
 					},
 					{
 						DisplayName: "Sleep Mode for Namespaces",
-						Name:        string(NamespaceSleepMode),
+						Name:        "namespace-sleep-mode",
 					},
 					{
 						DisplayName: "Connected Clusters",
-						Name:        string(ConnectedClusters),
+						Name:        "connected-clusters",
 					},
 					{
 						DisplayName: "Cluster Access",
-						Name:        string(ClusterAccess),
+						Name:        "cluster-access",
 					},
 					{
 						DisplayName: "Cluster Role Management",
-						Name:        string(ClusterRoles),
+						Name:        "cluster-roles",
 					},
 					{
 						DisplayName: "Single Sign-On",
-						Name:        string(SSOAuth),
+						Name:        "sso-authentication",
 					},
 					{
 						DisplayName: "Audit Logging",
-						Name:        string(AuditLogging),
+						Name:        "audit-logging",
 					},
 					{
 						DisplayName: "Automatic Auth For Ingresses",
-						Name:        string(AutoIngressAuth),
+						Name:        "auto-ingress-authentication",
 					},
 					{
 						DisplayName: "Loft as OIDC Provider",
-						Name:        string(OIDCProvider),
+						Name:        "oidc-provider",
 					},
 					{
 						DisplayName: "Multiple SSO Providers",
-						Name:        string(MultipleSSOProviders),
+						Name:        "multiple-sso-providers",
 					},
 					{
 						DisplayName: "Apps",
-						Name:        string(Apps),
+						Name:        "apps",
 					},
 					{
 						DisplayName: "Template Versioning",
-						Name:        string(TemplateVersioning),
+						Name:        "template-versioning",
 					},
 					{
 						DisplayName: "Argo Integration",
-						Name:        string(ArgoIntegration),
+						Name:        "argo-integration",
 					},
 					{
 						DisplayName: "Rancher Integration",
-						Name:        string(RancherIntegration),
+						Name:        "rancher-integration",
 					},
 					{
 						DisplayName: "Secrets Sync",
-						Name:        string(Secrets),
+						Name:        "secrets",
 					},
 					{
 						DisplayName: "Secrets Encryption",
-						Name:        string(SecretEncryption),
+						Name:        "secret-encryption",
 					},
 					{
 						DisplayName: "HashiCorp Vault Integration",
-						Name:        string(VaultIntegration),
+						Name:        "vault-integration",
 					},
 					{
 						DisplayName: "High-Availability Mode",
-						Name:        string(HighAvailabilityMode),
+						Name:        "ha-mode",
 					},
 					{
 						DisplayName: "Multi-Region Mode",
-						Name:        string(MultiRegionMode),
+						Name:        "multi-region-mode",
 					},
 					{
 						DisplayName: "Air-Gapped Mode",
-						Name:        string(AirGappedMode),
+						Name:        "air-gapped-mode",
 					},
 					{
 						DisplayName: "Custom Branding",
-						Name:        string(CustomBranding),
+						Name:        "custom-branding",
 					},
 					{
 						DisplayName: "Advanced UI Customizations",
-						Name:        string(AdvancedUICustomizations),
-					},
-					{
-						DisplayName: "Custom Branding",
-						Name:        string(CustomBranding),
-					},
-					{
-						DisplayName: "Advanced UI Customizations",
-						Name:        string(AdvancedUICustomizations),
+						Name:        "advanced-ui-customizations",
 					},
 				},
 			},

--- a/pkg/licenseapi/license_new.go
+++ b/pkg/licenseapi/license_new.go
@@ -1,95 +1,41 @@
 package licenseapi
 
-var Limits = map[ResourceName]*Limit{
-	ConnectedClusterLimit: {
-		DisplayName: "Connected Clusters",
-		Name:        string(ConnectedClusterLimit),
-	},
-	VirtualClusterInstanceLimit: {
-		DisplayName: "Virtual Clusters",
-		Name:        string(VirtualClusterInstanceLimit),
-	},
-	DevPodWorkspaceInstanceLimit: {
-		DisplayName: "Dev Environments",
-		Name:        string(DevPodWorkspaceInstanceLimit),
-	},
-	UserLimit: {
-		DisplayName: "Users",
-		Name:        string(UserLimit),
-	},
-	InstanceLimit: {
-		DisplayName: "Instances",
-		Name:        string(InstanceLimit),
-	},
-}
-
-func New(product ProductName) *License {
-	allowedStatus := string(FeatureStatusActive)
-
-	connectedClusterStatus := string(FeatureStatusActive)
-	if product != VClusterPro && product != Loft {
-		connectedClusterStatus = string(FeatureStatusDisallowed)
-	}
-
-	namespaceStatus := string(FeatureStatusActive)
-	if product != Loft {
-		namespaceStatus = string(FeatureStatusDisallowed)
-	}
-
-	virtualClusterStatus := string(FeatureStatusActive)
-	if product != VClusterPro && product != Loft {
-		virtualClusterStatus = string(FeatureStatusDisallowed)
-	}
-
-	devpodStatus := string(FeatureStatusActive)
-	if product != DevPodPro {
-		devpodStatus = string(FeatureStatusDisallowed)
+func New() *License {
+	limits := make([]*Limit, 0, len(Limits))
+	for _, limit := range Limits {
+		limits = append(limits, limit)
 	}
 
 	return &License{
 		Modules: []*Module{
 			{
-				DisplayName: "Virtual Clusters",
+				DisplayName: "All Features",
 				Name:        string(VirtualClusterModule),
-				Limits: []*Limit{
-					Limits[VirtualClusterInstanceLimit],
-				},
+				Limits:      limits,
 				Features: []*Feature{
 					{
 						DisplayName: "Virtual Cluster Management",
 						Name:        string(VirtualCluster),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Sleep Mode for Virtual Clusters",
 						Name:        string(VirtualClusterSleepMode),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Central HostPath Mapper",
 						Name:        string(VirtualClusterHostPathMapper),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Enterprise Plugins",
 						Name:        string(VirtualClusterEnterprisePlugins),
-						Status:      virtualClusterStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "vCluster.Pro Distro",
-				Name:        string(VClusterProDistroModule),
-				Features: []*Feature{
 					{
 						DisplayName: "Security-Hardened vCluster Image",
 						Name:        string(VirtualClusterProDistroImage),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Built-In CoreDNS",
 						Name:        string(VirtualClusterProDistroBuiltInCoreDNS),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Virtual Admission Control",
@@ -99,52 +45,42 @@ func New(product ProductName) *License {
 					{
 						DisplayName: "Sync Patches",
 						Name:        string(VirtualClusterProDistroSyncPatches),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Embedded etcd",
 						Name:        string(VirtualClusterProDistroEmbeddedEtcd),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Isolated Control Plane",
 						Name:        string(VirtualClusterProDistroIsolatedControlPlane),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Centralized Admission Control",
 						Name:        string(VirtualClusterProDistroCentralizedAdmissionControl),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Generic Sync",
 						Name:        string(VirtualClusterProDistroGenericSync),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Translate Patches",
 						Name:        string(VirtualClusterProDistroTranslatePatches),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "KubeVirt Integration",
 						Name:        string(VirtualClusterProDistroIntegrationsKubeVirt),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "External Secrets Integration",
 						Name:        string(VirtualClusterProDistroIntegrationsExternalSecrets),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "Cert Manager Integration",
 						Name:        string(VirtualClusterProDistroIntegrationsCertManager),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "FIPS",
 						Name:        string(VirtualClusterProDistroFips),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "External Database",
@@ -153,193 +89,112 @@ func New(product ProductName) *License {
 					{
 						DisplayName: "Database Connector",
 						Name:        string(ConnectorExternalDatabase),
-						Status:      virtualClusterStatus,
 					},
 					{
 						DisplayName: "SleepMode",
 						Name:        string(VirtualClusterProDistroSleepMode),
-						Status:      virtualClusterStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "Dev Environments",
-				Name:        string(DevPodModule),
-				Limits: []*Limit{
-					Limits[DevPodWorkspaceInstanceLimit],
-				},
-				Features: []*Feature{
 					{
 						DisplayName: "Dev Environment Management",
 						Name:        string(Devpod),
-						Status:      devpodStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "Kubernetes Namespaces",
-				Name:        string(KubernetesNamespaceModule),
-				Features: []*Feature{
 					{
 						DisplayName: "Namespace Management",
 						Name:        string(Namespaces),
-						Status:      namespaceStatus,
 					},
 					{
 						DisplayName: "Sleep Mode for Namespaces",
 						Name:        string(NamespaceSleepMode),
-						Status:      namespaceStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "Kubernetes Clusters",
-				Name:        string(KubernetesClusterModule),
-				Limits: []*Limit{
-					Limits[ConnectedClusterLimit],
-				},
-				Features: []*Feature{
 					{
 						DisplayName: "Connected Clusters",
 						Name:        string(ConnectedClusters),
-						Status:      connectedClusterStatus,
 					},
 					{
 						DisplayName: "Cluster Access",
 						Name:        string(ClusterAccess),
-						Status:      connectedClusterStatus,
 					},
 					{
 						DisplayName: "Cluster Role Management",
 						Name:        string(ClusterRoles),
-						Status:      connectedClusterStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "Authentication & Audit Logging",
-				Name:        string(AuthModule),
-				Limits: []*Limit{
-					Limits[UserLimit],
-				},
-				Features: []*Feature{
 					{
 						DisplayName: "Single Sign-On",
 						Name:        string(SSOAuth),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Audit Logging",
 						Name:        string(AuditLogging),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Automatic Auth For Ingresses",
 						Name:        string(AutoIngressAuth),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Loft as OIDC Provider",
 						Name:        string(OIDCProvider),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Multiple SSO Providers",
 						Name:        string(MultipleSSOProviders),
-						Status:      allowedStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "Templating & GitOps",
-				Name:        string(TemplatingModule),
-				Features: []*Feature{
 					{
 						DisplayName: "Apps",
 						Name:        string(Apps),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Template Versioning",
 						Name:        string(TemplateVersioning),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Argo Integration",
 						Name:        string(ArgoIntegration),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Rancher Integration",
 						Name:        string(RancherIntegration),
-						Status:      allowedStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "Secrets Management",
-				Name:        string(SecretsModule),
-				Features: []*Feature{
 					{
 						DisplayName: "Secrets Sync",
 						Name:        string(Secrets),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Secrets Encryption",
 						Name:        string(SecretEncryption),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "HashiCorp Vault Integration",
 						Name:        string(VaultIntegration),
-						Status:      allowedStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "Deployment Modes",
-				Name:        string(DeploymentModesModule),
-				Limits: []*Limit{
-					Limits[InstanceLimit],
-				},
-				Features: []*Feature{
 					{
 						DisplayName: "High-Availability Mode",
 						Name:        string(HighAvailabilityMode),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Multi-Region Mode",
 						Name:        string(MultiRegionMode),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Air-Gapped Mode",
 						Name:        string(AirGappedMode),
-						Status:      allowedStatus,
 					},
-				},
-			},
-			{
-				DisplayName: "UI Customization",
-				Name:        string(UIModule),
-				Features: []*Feature{
 					{
 						DisplayName: "Custom Branding",
 						Name:        string(CustomBranding),
-						Status:      allowedStatus,
 					},
 					{
 						DisplayName: "Advanced UI Customizations",
 						Name:        string(AdvancedUICustomizations),
-						Status:      allowedStatus,
+					},
+					{
+						DisplayName: "Custom Branding",
+						Name:        string(CustomBranding),
+					},
+					{
+						DisplayName: "Advanced UI Customizations",
+						Name:        string(AdvancedUICustomizations),
 					},
 				},
-			},
-			{
-				DisplayName: "vCluster Sleep Mode",
-				Name:        string(VirtualClusterSleepMode),
 			},
 		},
 	}


### PR DESCRIPTION
 Extend code generation and compact modules

Prior, we were organizing features by modules. This is no longer
needed. Now, all features are included under one module. We preserved
the module structure to maintain compatibility. Code generation now
covers the new license function. This was done to simplify adding
new features.

This PR along with the other code gen PR happened to resolve some mistakes as well like the module that was added instead of a feature.

Note: Some of this is temporary. Once pending changes are made to license service, it will no longer have need for the `licenseapi.New()` function. I already wrote this before realizing that we can scrap this portion so I propose we keep it to simplify adding features until it has been removed.

Part of ENG-5495.