### PR TITLE
Add internal features back

### DIFF
--- a/pkg/licenseapi/features_internal.go
+++ b/pkg/licenseapi/features_internal.go
@@ -1,0 +1,13 @@
+package licenseapi
+
+// Internal Features - not to be directly used by the license service
+
+const (
+	Metrics FeatureName = "metrics"
+
+	Runners FeatureName = "runners"
+
+	ConnectLocalCluster FeatureName = "connect-local-cluster"
+
+	PasswordAuthentication FeatureName = "password-auth"
+)


### PR DESCRIPTION
Internal features are not intended to be used by license service or uploaded to Stripe. They are not part of features yaml and are instead added in a separate non-generated file.