### PR TITLE
Clarifies what vcp-distro-generic-sync actually does

### DIFF
--- a/definitions/features.yaml
+++ b/definitions/features.yaml
@@ -377,7 +377,7 @@ features:
 
 # NEEDS FIXING
 - name: "vcp-distro-generic-sync"
-  displayName: "Generic Sync"
+  displayName: "Custom Resource Syncing"
   module: "syncing"
   ui:
     hidden: true

--- a/pkg/licenseapi/features.go
+++ b/pkg/licenseapi/features.go
@@ -118,7 +118,7 @@ const (
 
 	AutoNodesMetal3 FeatureName = "auto-nodes-metal3" // Metal3 Node Provider
 
-	VirtualClusterProDistroGenericSync FeatureName = "vcp-distro-generic-sync" // Generic Sync
+	VirtualClusterProDistroGenericSync FeatureName = "vcp-distro-generic-sync" // Custom Resource Syncing
 
 	VirtualClusterProDistroSyncPatches FeatureName = "vcp-distro-sync-patches" // Sync Patches
 
@@ -518,7 +518,7 @@ func GetAllFeatures() []*Feature {
 			Module:      "auto-nodes",
 		},
 		{
-			DisplayName: "Generic Sync",
+			DisplayName: "Custom Resource Syncing",
 			Name:        "vcp-distro-generic-sync",
 			Module:      "syncing",
 		},


### PR DESCRIPTION
Closes previous PRs as they didn't generate other files.