### PR TITLE
Add blocking enforcement for CPU and GPU limits

### DIFF
--- a/pkg/licenseapi/license_limit.go
+++ b/pkg/licenseapi/license_limit.go
@@ -25,6 +25,14 @@ var Limits = map[ResourceName]*Limit{
 		DisplayName: "Instances",
 		Name:        string(InstanceLimit),
 	},
+	CpuLimit: {
+		DisplayName: "CPUs",
+		Name:        string(CpuLimit),
+	},
+	GpuLimit: {
+		DisplayName: "GPUs",
+		Name:        string(GpuLimit),
+	},
 }
 
 // Limit defines a limit set in the license

--- a/pkg/licenseapi/names.go
+++ b/pkg/licenseapi/names.go
@@ -83,6 +83,8 @@ const (
 	DevPodWorkspaceInstanceLimit  ResourceName = "devpod-workspace-instance"
 	UserLimit                     ResourceName = "user"
 	InstanceLimit                 ResourceName = "instance"
+	CpuLimit                      ResourceName = "cpu"
+	GpuLimit                      ResourceName = "gpu"
 )
 
 // Resource Status


### PR DESCRIPTION
Discussed with Lukas. We want to block if the "total" is set- this is necessary to do that. This primarily applies to the free plan. If "committed" like in most of our plans, they won't be blocked, and we will instead charge for overages.
Fixes ENGPLAT-496

Limits set in stripe need to be reviewed before merge. Do not merge.