### PR TITLE
ci: add renovate config

### DIFF
--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -1,0 +1,19 @@
+# Caller workflow for the reusable validate-renovate workflow in loft-sh/github-actions.
+name: Validate Renovate Config
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - 'renovate.json5'
+      - '.renovaterc'
+      - '.renovaterc.json'
+
+permissions: {}
+
+jobs:
+  validate-renovate:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: loft-sh/github-actions/.github/workflows/validate-renovate.yaml@b52efbd927586ea78282073f79d2423e552c9f62 # validate-renovate/v1

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "baseBranchPatterns": ["main"],
+  "labels": ["dependencies"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "minimumReleaseAge": "3 days",
+  "schedule": ["before 6am on monday"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group Go patch updates to reduce PR noise; majors and minors stay individual for review",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "go-patch-updates"
+    },
+    {
+      "description": "Group Kubernetes Go modules so the k8s.io/sigs.k8s.io ecosystem moves in lockstep (covers go.mod deps and the pinned code-generator/kube-openapi tools in the Justfile)",
+      "matchPackageNames": ["k8s.io/{/,}**", "sigs.k8s.io/{/,}**"],
+      "groupName": "k8s-go-deps"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "deepcopy-gen (k8s.io/code-generator) tool version in the Justfile gen recipe",
+      "managerFilePatterns": ["/^Justfile$/"],
+      "matchStrings": ["go run k8s\\.io/code-generator/cmd/deepcopy-gen@(?<currentValue>v[\\d.]+)"],
+      "depNameTemplate": "k8s.io/code-generator",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "openapi-gen (k8s.io/kube-openapi) tool version in the Justfile gen recipe",
+      "managerFilePatterns": ["/^Justfile$/"],
+      "matchStrings": ["go run k8s\\.io/kube-openapi/cmd/openapi-gen@(?<currentValue>v[\\d.]+-[\\d]+-[0-9a-f]+)"],
+      "depNameTemplate": "k8s.io/kube-openapi",
+      "datasourceTemplate": "go"
+    }
+  ]
+}


### PR DESCRIPTION
Closes DEVOPS-969

## Summary
- Onboard Renovate for this public Go API/library, covering go.mod, GitHub Actions, and the pinned code-generator tools in the `Justfile`.
- Conservative policy: Go patch updates grouped, the k8s.io/sigs.k8s.io ecosystem grouped so it moves in lockstep; majors and minors stay individual PRs for review.
- Add the `validate-renovate` CI caller workflow so config edits are validated on every PR.

## Coverage

| Dependency surface | Manager |
|---|---|
| `go.mod` requires (26 deps incl. `go` directive, `k8s.io/*`, `sigs.k8s.io/*`, stripe-go, x/*, protobuf) | built-in `gomod` (+ `gomodTidy`) |
| `.github/workflows/*.yaml` `uses:` actions (checkout, setup-go, golangci-lint-action) + the new validate-renovate pin | built-in `github-actions` (digests pinned via `helpers:pinGitHubActionDigests`) |
| `go-version: "1.22"` in `go.yml` setup-go step | built-in `github-actions` (native go-version detection) |
| `go run k8s.io/code-generator/cmd/deepcopy-gen@v0.28.1` in `Justfile` | custom regex manager (datasource `go`) |
| `go run k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-...` in `Justfile` | custom regex manager (datasource `go`) |

The two `Justfile` tool pins use depNames `k8s.io/code-generator` and `k8s.io/kube-openapi`, so they group under `k8s-go-deps` alongside the matching go.mod entries.

## Deliberately not managed

- **`go run github.com/dkorunic/betteralign/cmd/betteralign@latest` (`Justfile`)** — pinned to `@latest`, not a fixed version, so there is nothing for Renovate to bump. Left as-is.
- **No `replace` directives, no `vendor/`, no Dockerfiles, no Terraform, no Helm charts, no `.tool-versions`, no proto/buf toolchain, no `dependabot.yml`** — none exist in this repo, so no managers or removals were needed.

## Test plan
- `renovate-config-validator renovate.json` — passed ("Config validated successfully").
- Custom regex managers verified with python3's `re` module against the real files — each `matchString` matches **exactly once**:
  - deepcopy-gen pattern -> 1 match (`v0.28.1`)
  - openapi-gen pattern -> 1 match (`v0.0.0-20260127142750-a19766b6e2d4`)
- `LOG_LEVEL=debug renovate --platform=local --dry-run=extract` — 7 package files found across managers: `github-actions` (4 workflow files, incl. go-version + validate-renovate digest), `gomod` (go.mod, 26 deps), `regex` (2 Justfile tool pins). Every ecosystem from the inventory is covered.
- `actionlint` on the new workflow — 0 findings.
- `zizmor` on the new workflow — 0 findings (reusable workflow pinned to SHA `b52efbd927586ea78282073f79d2423e552c9f62` for `validate-renovate/v1`).

## Post-merge checklist
- [ ] Dependency Dashboard issue appears and the first run resolves all managers (gomod, github-actions, 2x regex).
- [ ] Existing GitHub security alerts start getting `security`-labeled PRs (bypass the weekly schedule).
