### PR TITLE
Replace observability feature with fleet-observability

### DIFF
--- a/definitions/features.yaml
+++ b/definitions/features.yaml
@@ -28,7 +28,7 @@ features:
   displayName: "Fleet Observability"
   module: "platform"
   ui:
-    description: "Monitor all your fleets at a glance, then drill down into individual tenant cluster health with built-in dashboards."
+    description: "Monitor all your clusters at a glance, then drill down into individual tenant cluster health with built-in dashboards."
     docsLink: ""
 - name: "secrets"
   displayName: "Secrets Sync"

--- a/definitions/features.yaml
+++ b/definitions/features.yaml
@@ -24,11 +24,11 @@ features:
   ui:
     description: "Connected Clusters are centrally managed kubernetes clusters to run virtual clusters and namespaces on.  "
     docsLink: "https://www.vcluster.com/docs/platform/administer/clusters/connect-cluster"
-- name: "observability"
-  displayName: "Observability"
+- name: "fleet-observability"
+  displayName: "Fleet Observability"
   module: "platform"
   ui:
-    description: "Monitor all your clusters at a glance, then drill down into individual tenant cluster health with built-in dashboards."
+    description: "Monitor all your fleets at a glance, then drill down into individual tenant cluster health with built-in dashboards."
     docsLink: ""
 - name: "secrets"
   displayName: "Secrets Sync"

--- a/definitions/generated/modules_generated.yaml
+++ b/definitions/generated/modules_generated.yaml
@@ -80,7 +80,7 @@ modules:
   - cluster-access
   - cluster-roles
   - connected-clusters
-  - observability
+  - fleet-observability
   - secrets
   - apps
   - namespaces

--- a/pkg/licenseapi/features.go
+++ b/pkg/licenseapi/features.go
@@ -10,7 +10,7 @@ const (
 
 	ConnectedClusters FeatureName = "connected-clusters" // Connected Clusters
 
-	Observability FeatureName = "observability" // Observability
+	FleetObservability FeatureName = "fleet-observability" // Fleet Observability
 
 	Secrets FeatureName = "secrets" // Secrets Sync
 
@@ -163,7 +163,7 @@ func GetFeatures() []FeatureName {
 		ClusterAccess,
 		ClusterRoles,
 		ConnectedClusters,
-		Observability,
+		FleetObservability,
 		Secrets,
 		Apps,
 		Namespaces,
@@ -257,8 +257,8 @@ func GetAllFeatures() []*Feature {
 			Module:      "platform",
 		},
 		{
-			DisplayName: "Observability",
-			Name:        "observability",
+			DisplayName: "Fleet Observability",
+			Name:        "fleet-observability",
 			Module:      "platform",
 		},
 		{


### PR DESCRIPTION
Replaces the observability feature gate with fleet-observability terminology across all feature definitions and generated modules to align with updated terminology.
